### PR TITLE
renovate: Only consider github releases when bumping engine

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     "**/tests/suites/**",
     "**/__fixtures__/**"
   ],
-  "commitBody": "Update {{depName}}\nChange-type: patch",
+  "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: {{updateType}}",
   "regexManagers": [
     {
       "fileMatch": ["(^|/)balena-supervisor.inc$"],
@@ -25,27 +25,28 @@
       "matchStrings": ["BALENA_VERSION = \"v?(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "balena-engine",
       "packageNameTemplate": "balena-os/balena-engine",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],
   "packageRules": [
     {
+      "matchManagers": ["git-submodules"],
+      "commitBody": "Update {{depName}}\nChange-type: patch",
+      "automerge": true
+    },
+    {
       "matchManagers": ["regex"],
-      "matchPackagePatterns": [
-        ".*balena-supervisor",
-        ".*balena-engine"
-      ],
-      "commitBody": "Update {{depName}} from {{currentVersion}} to {{newVersion}}\n\nChange-type: {{updateType}}",
-      "automerge": true,
-      "platformAutomerge": true,
+      "automerge": true
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchPackagePatterns": [".*balena-engine"],
       "postUpgradeTasks": {
         "commands": [
           "sed -r \"s|SRCREV = \\\"[0-9a-f]+\\\"|SRCREV = \\\"$(git ls-remote -t {{{sourceUrl}}} refs/tags/v{{{newVersion}}} | awk '{print $1}')\\\"|\" -i {{{packageFile}}}"
         ],
-        "fileFilters": [
-          "**/balena_git.bb"
-        ],
+        "fileFilters": ["**/balena_git.bb"],
         "executionMode": "update"
       }
     }


### PR DESCRIPTION
The engine is currently versioned in such a way that upstream semver tags are added to branches before merging to master.

We don't want to try and pin to those commits so only consider automated GitHub Releases.

Change-type: patch


---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
  - [ ] Covered in automated test suite
  - [ ] Manual test case recorded
- [ ] `Change-type` present on at least one commit
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)
<!-- optional: `Changelog-entry` present on at least one commit if you want to set the changelog entry manually-->

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
